### PR TITLE
[Fix] Fix circular import of PromptTemplate

### DIFF
--- a/opencompass/openicl/icl_retriever/icl_base_retriever.py
+++ b/opencompass/openicl/icl_retriever/icl_base_retriever.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 
 from mmengine.dist import is_main_process
 
-from opencompass.openicl import PromptTemplate
+from opencompass.openicl.icl_prompt_template import PromptTemplate
 from opencompass.utils.prompt import PromptList
 
 

--- a/opencompass/openicl/icl_retriever/icl_mdl_retriever.py
+++ b/opencompass/openicl/icl_retriever/icl_mdl_retriever.py
@@ -7,7 +7,7 @@ import torch
 import tqdm
 from transformers import AutoModelForCausalLM
 
-from opencompass.openicl import PromptTemplate
+from opencompass.openicl.icl_prompt_template import PromptTemplate
 from opencompass.openicl.icl_retriever.icl_topk_retriever import TopkRetriever
 from opencompass.openicl.utils.logging import get_logger
 from opencompass.registry import ICL_PROMPT_TEMPLATES, ICL_RETRIEVERS


### PR DESCRIPTION
Fix the error caused by reordering the init statements:
```
│     7 import tqdm                                                            │                        
│     8 from transformers import AutoModelForCausalLM                          │                                                                                                                                                                       
│     9                                                                        │                         
│ ❱  10 from opencompass.openicl import PromptTemplate                         │                                                                                                                                                                       │    11 from opencompass.openicl.icl_retriever.icl_topk_retriever import TopkR │                        
│    12 from opencompass.openicl.utils.logging import get_logger               │
│    13 from opencompass.registry import ICL_PROMPT_TEMPLATES, ICL_RETRIEVERS  │                                 
╰──────────────────────────────────────────────────────────────────────────────╯
ImportError: cannot import name 'PromptTemplate' from partially initialized                               
module 'opencompass.openicl' (most likely due to a circular import)  
```