### PR TITLE
[Feature] Evaluating acc based on minimum edit distance, update SIQA

### DIFF
--- a/configs/datasets/siqa/siqa_gen_e78df3.py
+++ b/configs/datasets/siqa/siqa_gen_e78df3.py
@@ -1,13 +1,13 @@
 from opencompass.openicl.icl_prompt_template import PromptTemplate
 from opencompass.openicl.icl_retriever import ZeroRetriever
 from opencompass.openicl.icl_inferencer import GenInferencer
-from opencompass.openicl.icl_evaluator import AccEvaluator
+from opencompass.openicl.icl_evaluator import EDAccEvaluator
 from opencompass.datasets import siqaDataset_V2
-from opencompass.utils.text_postprocessors import first_capital_postprocess
+# from opencompass.utils.text_postprocessors import first_capital_postprocess
 
 siqa_reader_cfg = dict(
     input_columns=["context", "question", "answerA", "answerB", "answerC"],
-    output_column="label",
+    output_column="all_labels",
     test_split="validation")
 
 siqa_infer_cfg = dict(
@@ -27,9 +27,8 @@ siqa_infer_cfg = dict(
 )
 
 siqa_eval_cfg = dict(
-    evaluator=dict(type=AccEvaluator),
+    evaluator=dict(type=EDAccEvaluator),
     pred_role="BOT",
-    pred_postprocessor=dict(type=first_capital_postprocess),
 )
 
 siqa_datasets = [

--- a/configs/datasets/siqa/siqa_gen_e78df3.py
+++ b/configs/datasets/siqa/siqa_gen_e78df3.py
@@ -3,7 +3,6 @@ from opencompass.openicl.icl_retriever import ZeroRetriever
 from opencompass.openicl.icl_inferencer import GenInferencer
 from opencompass.openicl.icl_evaluator import EDAccEvaluator
 from opencompass.datasets import siqaDataset_V2
-# from opencompass.utils.text_postprocessors import first_capital_postprocess
 
 siqa_reader_cfg = dict(
     input_columns=["context", "question", "answerA", "answerB", "answerC"],

--- a/opencompass/datasets/siqa.py
+++ b/opencompass/datasets/siqa.py
@@ -13,6 +13,15 @@ class siqaDataset_V2(BaseDataset):
         dataset = load_dataset(**kwargs)
 
         def preprocess(example):
+            example['all_labels'] = {
+                'candidates': [
+                    f'A. {example["answerA"]}',
+                    f'B. {example["answerB"]}',
+                    f'C. {example["answerC"]}',
+                ],
+                'label':
+                int(example['label']) - 1
+            }
             example['label'] = ' ABC'[int(example['label'])]
             return example
 


### PR DESCRIPTION
Prior to that, the only clue to determine whether the model made a right choice in multiple-choice questions is by strictly matching the leading capital character, which may underestimate the model's performance if the model tends to output the choice content instead of the leading character.

Now the model's choice can be matched to the one which has the minimum edit distance.

Addressing https://github.com/InternLM/opencompass/issues/52