### PR TITLE
[Fix] Use a copy of the config object in Task

### DIFF
--- a/opencompass/tasks/base.py
+++ b/opencompass/tasks/base.py
@@ -1,3 +1,4 @@
+import copy
 import os
 from abc import abstractmethod
 from typing import List
@@ -25,6 +26,7 @@ class BaseTask:
     output_subdir: str = None
 
     def __init__(self, cfg: ConfigDict):
+        cfg = copy.deepcopy(cfg)
         self.cfg = cfg
         self.model_cfgs = cfg['models']
         self.dataset_cfgs = cfg['datasets']


### PR DESCRIPTION
## Motivation

In debugging mode, the config objects are directly passed to Task instances, which may modify the fields inside and cause some unexpected errors in other processes that assume the sanity of the config.

Closing #171 

## Modification

Use a copy of the config object in Task.