### PR TITLE
[Fix] Fix bugs of multiple rounds of inference when using mm_eval

### DIFF
--- a/opencompass/tasks/mm_infer.py
+++ b/opencompass/tasks/mm_infer.py
@@ -6,6 +6,7 @@ import random
 import time
 from typing import List, Sequence
 
+import mmengine
 import torch
 import torch.distributed as dist
 from mmengine.config import Config, ConfigDict
@@ -75,8 +76,8 @@ class MultimodalInferTask:
         dataset_name = self.dataloader['dataset']['type']
         evaluator_name = self.evaluator[0]['type']
 
-        return osp.join(model_name,
-                        f'{dataset_name}-{evaluator_name}.{file_extension}')
+        return osp.join(self.cfg.work_dir, model_name, dataset_name,
+                        f'{evaluator_name}.{file_extension}')
 
     def get_output_paths(self, file_extension: str = 'json') -> List[str]:
         """Get the path to the output file.
@@ -90,7 +91,7 @@ class MultimodalInferTask:
         evaluator_name = self.evaluator[0]['type']
 
         return [
-            osp.join(model_name, dataset_name,
+            osp.join(self.cfg.work_dir, model_name, dataset_name,
                      f'{evaluator_name}.{file_extension}')
         ]
 
@@ -134,7 +135,8 @@ class MultimodalInferTask:
             evaluator.process(data_samples)
 
         metrics = evaluator.evaluate(len(dataloader.dataset))
-        metrics_file = osp.join(cfg.work_dir, 'res.log')
+        metrics_file = self.get_output_paths()[0]
+        mmengine.mkdir_or_exist(osp.split(metrics_file)[0])
         with open(metrics_file, 'w') as f:
             json.dump(metrics, f)
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Inference with --mm-eval arg leads to multiple rounds of running.

## Modification

In slurm runner, the task reruns when job failure is detected, the related code is as below:
https://github.com/InternLM/opencompass/blob/4fc1701209adad832f7fca91640fac34331b8e29/opencompass/runners/slurm.py#L150-L152

And the output path is obtained by calling `task.get_output_paths()`:
https://github.com/InternLM/opencompass/blob/4fc1701209adad832f7fca91640fac34331b8e29/opencompass/runners/slurm.py#L129-L131

However, in `MultimodalInferTask`, the returned path of `get_output_paths` method is different with the path of the output result.
The `get_output_paths` method returns:
https://github.com/InternLM/opencompass/blob/4fc1701209adad832f7fca91640fac34331b8e29/opencompass/tasks/mm_infer.py#L92-L95

And the result is dumped into:
https://github.com/InternLM/opencompass/blob/4fc1701209adad832f7fca91640fac34331b8e29/opencompass/tasks/mm_infer.py#L136-L139

Therefore, when the task is finished successfully, the `get_output_paths` directory does not exist since the result is saved somewhere else. Then the runner rerun the task.

So in this PR, we modify the saving path from `work_dir` to `get_output_paths`.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
