### PR TITLE
[Feature] Support model-bound prediction postprocessor, use it in Claude

### DIFF
--- a/configs/eval_claude.py
+++ b/configs/eval_claude.py
@@ -1,0 +1,19 @@
+from mmengine.config import read_base
+from opencompass.partitioners import NaivePartitioner
+from opencompass.runners import LocalRunner
+from opencompass.tasks import OpenICLInferTask
+
+with read_base():
+    # choose a list of datasets
+    from .datasets.collections.chat_medium import datasets
+    # and output the results in a choosen format
+    from .summarizers.medium import summarizer
+    from .models.claude import models
+
+infer = dict(
+    partitioner=dict(type=NaivePartitioner),
+    runner=dict(
+        type=LocalRunner,
+        max_num_workers=8,
+        task=dict(type=OpenICLInferTask)),
+)

--- a/configs/eval_claude2.py
+++ b/configs/eval_claude2.py
@@ -12,6 +12,56 @@ with read_base():
     # and output the results in a choosen format
     from .summarizers.medium import summarizer
 
+agieval_single_choice_sets = [
+    'gaokao-chinese',
+    'gaokao-english',
+    'gaokao-geography',
+    'gaokao-history',
+    'gaokao-biology',
+    'gaokao-chemistry',
+    'gaokao-mathqa',
+    'logiqa-zh',
+    'lsat-ar',
+    'lsat-lr',
+    'lsat-rc',
+    'logiqa-en',
+    'sat-math',
+    'sat-en',
+    'sat-en-without-passage',
+    'aqua-rat',
+]
+agieval_multiple_choices_sets = [
+    'gaokao-physics',
+    'jec-qa-kd',
+    'jec-qa-ca',
+]
+
+claude_postprocessors = {
+    'ceval-*': dict(type=last_option_postprocess, options='ABCD'),
+    'bustm-*': dict(type=last_option_postprocess, options='AB'),
+    'hellaswag': dict(type=last_option_postprocess, options='ABCD'),
+    'lukaemon_mmlu_*': dict(type=last_option_postprocess, options='ABCD'),
+    'openbookqa*': dict(type=last_option_postprocess, options='ABCD'),
+    'piqa': dict(type=last_option_postprocess, options='AB'),
+    'race-*': dict(type=last_option_postprocess, options='ABCD'),
+    'summedits': dict(type=last_option_postprocess, options='AB'),
+    'BoolQ': dict(type=last_option_postprocess, options='AB'),
+    'CB': dict(type=last_option_postprocess, options='ABC'),
+    'MultiRC': dict(type=last_option_postprocess, options='AB'),
+    'RTE': dict(type=last_option_postprocess, options='AB'),
+    'WiC': dict(type=last_option_postprocess, options='AB'),
+    'WSC': dict(type=last_option_postprocess, options='AB'),
+    'winogrande': dict(type=last_option_postprocess, options='AB'),
+    'gsm8k': dict(type=gsm8k_postprocess),
+    'openai_humaneval': dict(type=humaneval_postprocess),
+    'lcsts': dict(type=lcsts_postprocess),
+    'mbpp': dict(type=mbpp_postprocess),
+    'strategyqa': dict(type=strategyqa_pred_postprocess),
+}
+
+for _name in agieval_multiple_choices_sets + agieval_single_choice_sets:
+    claude_postprocessors[f'agieval-{_name}'] = dict(type=last_option_postprocess, options='ABCDE')
+
 models = [
     dict(abbr='Claude2',
         type=Claude,
@@ -19,31 +69,10 @@ models = [
         key='YOUR_CLAUDE_KEY',
         query_per_second=1,
         max_out_len=2048, max_seq_len=2048, batch_size=2,
-        pred_postprocessor={
-            'agieval-*': dict(type=last_option_postprocess, options='ABCDE'),
-            'ceval-*': dict(type=last_option_postprocess, options='ABCD'),
-            'bustm-*': dict(type=last_option_postprocess, options='AB'),
-            'hellaswag': dict(type=last_option_postprocess, options='ABCD'),
-            'lukaemon_mmlu_*': dict(type=last_option_postprocess, options='ABCD'),
-            'openbookqa': dict(type=last_option_postprocess, options='ABCD'),
-            'piqa': dict(type=last_option_postprocess, options='AB'),
-            'race-*': dict(type=last_option_postprocess, options='ABCD'),
-            'summedits': dict(type=last_option_postprocess, options='AB'),
-            'BoolQ': dict(type=last_option_postprocess, options='AB'),
-            'CB': dict(type=last_option_postprocess, options='ABC'),
-            'MultiRC': dict(type=last_option_postprocess, options='AB'),
-            'RTE': dict(type=last_option_postprocess, options='AB'),
-            'WiC': dict(type=last_option_postprocess, options='AB'),
-            'WSC': dict(type=last_option_postprocess, options='AB'),
-            'winogrande': dict(type=last_option_postprocess, options='AB'),
-            'gsm8k': dict(type=gsm8k_postprocess),
-            'openai_humaneval': dict(type=humaneval_postprocess),
-            'lcsts': dict(type=lcsts_postprocess),
-            'mbpp': dict(type=mbpp_postprocess),
-            'strategyqa': dict(type=strategyqa_pred_postprocess),
-        },
+        pred_postprocessor=claude_postprocessors,
         ),
 ]
+
 
 infer = dict(
     partitioner=dict(type=NaivePartitioner),

--- a/configs/eval_claude2.py
+++ b/configs/eval_claude2.py
@@ -1,8 +1,10 @@
 from mmengine.config import read_base
-from opencompass.models.claude_api import Claude
+from opencompass.models.claude_api.claude_api import Claude
 from opencompass.partitioners import NaivePartitioner
 from opencompass.runners import LocalRunner
 from opencompass.tasks import OpenICLInferTask
+from opencompass.utils.text_postprocessors import last_option_postprocess
+from opencompass.models.claude_api.postprocessors import gsm8k_postprocess, humaneval_postprocess, lcsts_postprocess, mbpp_postprocess, strategyqa_pred_postprocess
 
 with read_base():
     # choose a list of datasets
@@ -16,7 +18,31 @@ models = [
         path='claude-2',
         key='YOUR_CLAUDE_KEY',
         query_per_second=1,
-        max_out_len=2048, max_seq_len=2048, batch_size=2),
+        max_out_len=2048, max_seq_len=2048, batch_size=2,
+        pred_postprocessor={
+            'agieval-*': dict(type=last_option_postprocess, options='ABCDE'),
+            'ceval-*': dict(type=last_option_postprocess, options='ABCD'),
+            'bustm-*': dict(type=last_option_postprocess, options='AB'),
+            'hellaswag': dict(type=last_option_postprocess, options='ABCD'),
+            'lukaemon_mmlu_*': dict(type=last_option_postprocess, options='ABCD'),
+            'openbookqa': dict(type=last_option_postprocess, options='ABCD'),
+            'piqa': dict(type=last_option_postprocess, options='AB'),
+            'race-*': dict(type=last_option_postprocess, options='ABCD'),
+            'summedits': dict(type=last_option_postprocess, options='AB'),
+            'BoolQ': dict(type=last_option_postprocess, options='AB'),
+            'CB': dict(type=last_option_postprocess, options='ABC'),
+            'MultiRC': dict(type=last_option_postprocess, options='AB'),
+            'RTE': dict(type=last_option_postprocess, options='AB'),
+            'WiC': dict(type=last_option_postprocess, options='AB'),
+            'WSC': dict(type=last_option_postprocess, options='AB'),
+            'winogrande': dict(type=last_option_postprocess, options='AB'),
+            'gsm8k': dict(type=gsm8k_postprocess),
+            'openai_humaneval': dict(type=humaneval_postprocess),
+            'lcsts': dict(type=lcsts_postprocess),
+            'mbpp': dict(type=mbpp_postprocess),
+            'strategyqa': dict(type=strategyqa_pred_postprocess),
+        },
+        ),
 ]
 
 infer = dict(

--- a/configs/models/claude.py
+++ b/configs/models/claude.py
@@ -60,5 +60,5 @@ models = [
         query_per_second=1,
         max_out_len=2048, max_seq_len=2048, batch_size=2,
         pred_postprocessor=claude_postprocessors,
-        ),
+    ),
 ]

--- a/configs/models/claude.py
+++ b/configs/models/claude.py
@@ -1,0 +1,64 @@
+from opencompass.models.claude_api.claude_api import Claude
+from opencompass.utils.text_postprocessors import last_option_postprocess
+from opencompass.models.claude_api.postprocessors import gsm8k_postprocess, humaneval_postprocess, lcsts_postprocess, mbpp_postprocess, strategyqa_pred_postprocess
+
+agieval_single_choice_sets = [
+    'gaokao-chinese',
+    'gaokao-english',
+    'gaokao-geography',
+    'gaokao-history',
+    'gaokao-biology',
+    'gaokao-chemistry',
+    'gaokao-mathqa',
+    'logiqa-zh',
+    'lsat-ar',
+    'lsat-lr',
+    'lsat-rc',
+    'logiqa-en',
+    'sat-math',
+    'sat-en',
+    'sat-en-without-passage',
+    'aqua-rat',
+]
+agieval_multiple_choices_sets = [
+    'gaokao-physics',
+    'jec-qa-kd',
+    'jec-qa-ca',
+]
+
+claude_postprocessors = {
+    'ceval-*': dict(type=last_option_postprocess, options='ABCD'),
+    'bustm-*': dict(type=last_option_postprocess, options='AB'),
+    'hellaswag': dict(type=last_option_postprocess, options='ABCD'),
+    'lukaemon_mmlu_*': dict(type=last_option_postprocess, options='ABCD'),
+    'openbookqa*': dict(type=last_option_postprocess, options='ABCD'),
+    'piqa': dict(type=last_option_postprocess, options='AB'),
+    'race-*': dict(type=last_option_postprocess, options='ABCD'),
+    'summedits': dict(type=last_option_postprocess, options='AB'),
+    'BoolQ': dict(type=last_option_postprocess, options='AB'),
+    'CB': dict(type=last_option_postprocess, options='ABC'),
+    'MultiRC': dict(type=last_option_postprocess, options='AB'),
+    'RTE': dict(type=last_option_postprocess, options='AB'),
+    'WiC': dict(type=last_option_postprocess, options='AB'),
+    'WSC': dict(type=last_option_postprocess, options='AB'),
+    'winogrande': dict(type=last_option_postprocess, options='AB'),
+    'gsm8k': dict(type=gsm8k_postprocess),
+    'openai_humaneval': dict(type=humaneval_postprocess),
+    'lcsts': dict(type=lcsts_postprocess),
+    'mbpp': dict(type=mbpp_postprocess),
+    'strategyqa': dict(type=strategyqa_pred_postprocess),
+}
+
+for _name in agieval_multiple_choices_sets + agieval_single_choice_sets:
+    claude_postprocessors[f'agieval-{_name}'] = dict(type=last_option_postprocess, options='ABCDE')
+
+models = [
+    dict(abbr='Claude',
+        type=Claude,
+        path='claude-1',
+        key='YOUR_CLAUDE_KEY',
+        query_per_second=1,
+        max_out_len=2048, max_seq_len=2048, batch_size=2,
+        pred_postprocessor=claude_postprocessors,
+        ),
+]

--- a/configs/models/claude2.py
+++ b/configs/models/claude2.py
@@ -1,16 +1,6 @@
-from mmengine.config import read_base
 from opencompass.models.claude_api.claude_api import Claude
-from opencompass.partitioners import NaivePartitioner
-from opencompass.runners import LocalRunner
-from opencompass.tasks import OpenICLInferTask
 from opencompass.utils.text_postprocessors import last_option_postprocess
 from opencompass.models.claude_api.postprocessors import gsm8k_postprocess, humaneval_postprocess, lcsts_postprocess, mbpp_postprocess, strategyqa_pred_postprocess
-
-with read_base():
-    # choose a list of datasets
-    from .datasets.collections.chat_medium import datasets
-    # and output the results in a choosen format
-    from .summarizers.medium import summarizer
 
 agieval_single_choice_sets = [
     'gaokao-chinese',
@@ -72,12 +62,3 @@ models = [
         pred_postprocessor=claude_postprocessors,
         ),
 ]
-
-
-infer = dict(
-    partitioner=dict(type=NaivePartitioner),
-    runner=dict(
-        type=LocalRunner,
-        max_num_workers=8,
-        task=dict(type=OpenICLInferTask)),
-)

--- a/configs/models/claude2.py
+++ b/configs/models/claude2.py
@@ -60,5 +60,5 @@ models = [
         query_per_second=1,
         max_out_len=2048, max_seq_len=2048, batch_size=2,
         pred_postprocessor=claude_postprocessors,
-        ),
+    ),
 ]

--- a/opencompass/models/__init__.py
+++ b/opencompass/models/__init__.py
@@ -1,5 +1,6 @@
 from .base import BaseModel, LMTemplateParser  # noqa
 from .base_api import APITemplateParser, BaseAPIModel  # noqa
+from .claude_api import Claude  # noqa: F401
 from .glm import GLM130B  # noqa: F401, F403
 from .huggingface import HuggingFace  # noqa: F401, F403
 from .huggingface import HuggingFaceCausalLM  # noqa: F401, F403

--- a/opencompass/models/claude_api/__init__.py
+++ b/opencompass/models/claude_api/__init__.py
@@ -1,0 +1,3 @@
+from .claude_api import Claude
+
+__all__ = ['Claude']

--- a/opencompass/models/claude_api/claude_api.py
+++ b/opencompass/models/claude_api/claude_api.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Union
 from opencompass.registry import MODELS
 from opencompass.utils import PromptList
 
-from .base_api import BaseAPIModel
+from ..base_api import BaseAPIModel
 
 PromptType = Union[PromptList, str]
 

--- a/opencompass/models/claude_api/postprocessors.py
+++ b/opencompass/models/claude_api/postprocessors.py
@@ -1,0 +1,76 @@
+import re
+
+
+def gsm8k_postprocess(text: str) -> str:
+    text = text.split(' ')[::-1]
+    flag = False
+    ret = ''
+    for i in range(len(text)):
+        s = text[i]
+        for i in range(len(s)):
+            if s[i].isdigit():
+                flag = True
+                ret = s
+                break
+        if flag:
+            break
+    ret1 = ''
+    for i in range(len(ret)):
+        if ret[i].isdigit():
+            ret1 += ret[i]
+    return ret1
+
+
+def humaneval_postprocess(text: str) -> str:
+    text = '\n'.join(text.split('\n')[1:]).strip()
+    if '```' in text:
+        blocks = re.findall(r'```(.*?)```', text, re.DOTALL)
+        if len(blocks) == 0:
+            text = text.split('```')[1]  # fall back to default strategy
+        else:
+            text = blocks[0]  # fetch the first code block
+            if not text.startswith('\n'):  # in case starting with ```python
+                text = text[max(text.find('\n') + 1, 0):]
+    if text.strip().startswith('from') or text.strip().startswith('import'):
+        def_idx = text.find('def')
+        if def_idx != -1:
+            text = text[max(text.find('\n', def_idx) + 1, 0):]
+    if text.strip().startswith('def'):
+        text = '\n'.join(text.split('\n')[1:])
+    if not text.startswith('    '):
+        if text.startswith(' '):
+            text = '    ' + text.lstrip()
+        else:
+            text = '\n'.join(['    ' + line for line in text.split('\n')])
+    return text
+
+
+def lcsts_postprocess(text: str) -> str:
+    text = text.strip()
+    text = text.replace('1. ', '') if text.startswith('1. ') else text
+    text = text.replace('- ', '') if text.startswith('- ') else text
+    text = text.strip('“，。！”')
+    return text
+
+
+def mbpp_postprocess(text: str) -> str:
+    if text.startswith('Here'):
+        text = '\n'.join(text.split('\n')[1:]).strip()
+    if '```' in text:
+        blocks = re.findall(r'```(.*?)```', text, re.DOTALL)
+        if len(blocks) == 0:
+            text = text.split('```')[1]  # fall back to default strategy
+        else:
+            text = blocks[0]  # fetch the first code block
+            if not text.startswith('\n'):  # in case starting with ```python
+                text = text[max(text.find('\n') + 1, 0):]
+
+
+def strategyqa_pred_postprocess(text: str) -> str:
+    if text.startswith('Here'):
+        text = '\n'.join(text.split('\n')[1:]).strip()
+    text = text.split('answer is ')[-1]
+    match = re.search(r'(yes|no)', text.lower())
+    if match:
+        return match.group(1)
+    return ''

--- a/opencompass/models/claude_api/postprocessors.py
+++ b/opencompass/models/claude_api/postprocessors.py
@@ -64,6 +64,7 @@ def mbpp_postprocess(text: str) -> str:
             text = blocks[0]  # fetch the first code block
             if not text.startswith('\n'):  # in case starting with ```python
                 text = text[max(text.find('\n') + 1, 0):]
+    return text
 
 
 def strategyqa_pred_postprocess(text: str) -> str:

--- a/opencompass/tasks/openicl_eval.py
+++ b/opencompass/tasks/openicl_eval.py
@@ -51,7 +51,8 @@ class OpenICLEvalTask(BaseTask):
 
                 # overwrite postprocessor if the model has specified one
                 ds_abbr = dataset_abbr_from_cfg(self.dataset_cfg)
-                model_postprocessors = self.model_cfg.pred_postprocessor
+                model_postprocessors = self.model_cfg.get(
+                    'pred_postprocessor', {})
                 for pattern in model_postprocessors.keys():
                     if fnmatch.fnmatch(ds_abbr, pattern):
                         self.eval_cfg[

--- a/opencompass/utils/build.py
+++ b/opencompass/utils/build.py
@@ -19,4 +19,5 @@ def build_model_from_cfg(model_cfg: ConfigDict) -> ConfigDict:
     model_cfg.pop('max_out_len', None)
     model_cfg.pop('batch_size', None)
     model_cfg.pop('abbr', None)
+    model_cfg.pop('pred_postprocessor', None)
     return MODELS.build(model_cfg)

--- a/opencompass/utils/text_postprocessors.py
+++ b/opencompass/utils/text_postprocessors.py
@@ -79,3 +79,10 @@ def first_capital_postprocess_multi(text: str) -> str:
     if match:
         return match.group(1)
     return ''
+
+
+def last_option_postprocess(text: str, options: str) -> str:
+    match = re.findall(rf'([{options}])', text)
+    if match:
+        return match[-1]
+    return ''


### PR DESCRIPTION
## Motivation

Different models have different output styles, sometimes it's hard to share a universal postprocessor across all the models, which may underestimate some outlier's performance.

## Modification

This PR adds a `pred_postprocessor` parameter to `model`'s config, where users can customize postprocessors with respect to each datasets via a dataset_abbreviation -> postprocessor construction dict. The configuration from model side has the higher priority over the dataset-side.

## BC-breaking (Optional)

None

